### PR TITLE
No ItemAlert processing in Town.

### DIFF
--- a/src/Hud/Loot/ItemAlertPlugin.cs
+++ b/src/Hud/Loot/ItemAlertPlugin.cs
@@ -84,7 +84,7 @@ namespace PoeHUD.Hud.Loot
 
         protected override void OnEntityAdded(EntityWrapper entity)
         {
-            if (Settings.Enable && !currentAlerts.ContainsKey(entity) && entity.HasComponent<WorldItem>())
+            if (!GameController.Area.CurrentArea.IsTown && Settings.Enable && !currentAlerts.ContainsKey(entity) && entity.HasComponent<WorldItem>())
             {
                 IEntity item = entity.GetComponent<WorldItem>().ItemEntity;
                 // Check if we should alert WHILE loading item to preven useless compute


### PR DESCRIPTION
Prevent any processing of 'OnEntityAdded' while Current Area is a town (as we can't drop items we shouldn't even look at the entity).